### PR TITLE
close stale github issues automatically

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,18 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Comment or remove the stale label. Otherwise, it will be closed in 7 days.'
+          days-before-stale: 30
+          days-before-close: 7
+          exempt-issue-labels: 'feature, in-progress'


### PR DESCRIPTION
Stale issues after 30 days of inactive. Close stale issues after 7 days.
Issues with a feature or in-progress label will be exempted from being staled.