### PR TITLE
WebDAV Fix current Android / iOS clients

### DIFF
--- a/tests/tine20/Tinebase/WebDav/Plugin/OwnCloudTest.php
+++ b/tests/tine20/Tinebase/WebDav/Plugin/OwnCloudTest.php
@@ -60,11 +60,15 @@ class Tinebase_WebDav_Plugin_OwnCloudTest extends Tinebase_WebDav_Plugin_Abstrac
         $this->plugin = new Tinebase_WebDav_Plugin_OwnCloud();
 
         // Create request, there is no in tinebase while running unittests, but the owncloud plugin needs an user agent
+        $useragent = 'Mozilla/5.0 (Macintosh) mirall/2.2.4 (build 3709)';
+        if ('testInvalidOwnCloudVersion' == $this->getName()) {
+            $useragent = 'Mozilla/5.0 (Macintosh) mirall/1.5.0 (build 1234)';
+        }
         $request = Tinebase_Http_Request::fromString(
             "POST /index.php HTTP/1.1\r\n" .
             "Host: localhost\r\n" .
             "Content-Type: application/json\r\n" .
-            "User-Agent: Mozilla/5.0 (Macintosh) mirall/2.2.4 (build 3709)\r\n"
+            "User-Agent: {$useragent}\r\n"
         );
         Tinebase_Core::set(Tinebase_Core::REQUEST, $request);
 
@@ -341,14 +345,7 @@ class Tinebase_WebDav_Plugin_OwnCloudTest extends Tinebase_WebDav_Plugin_Abstrac
      */
     public function testInvalidOwnCloudVersion()
     {
-        // use old owncloud user agent!
-        $request = Tinebase_Http_Request::fromString(
-            "POST /index.php HTTP/1.1\r\n" .
-            "Host: localhost\r\n" .
-            "Content-Type: application/json\r\n" .
-            "User-Agent: Mozilla/5.0 (Macintosh) mirall/1.5.0 (build 3709)\r\n"
-        );
-        Tinebase_Core::set('request', $request);
+        // use old owncloud user agent! --> self::setUp() above
         $response = $this->_execPropfindRequest(expectedStatus: 500)->saveXML();
         $this->assertStringContainsString(InvalidArgumentException::class, $response);
         $this->assertStringContainsString(sprintf(

--- a/tine20/Tinebase/Webfinger.php
+++ b/tine20/Tinebase/Webfinger.php
@@ -11,6 +11,9 @@ class Tinebase_Webfinger
     {
         /** @var \Laminas\Diactoros\ServerRequest $request */
         $request = Tinebase_Core::getContainer()->get(\Psr\Http\Message\RequestInterface::class);
+        if (self::unpleasantRequest($request) == true) {
+            return static::notFound();
+        }
         $params = $request->getQueryParams();
         if (!isset($params['resource']) || !isset($params['rel'])) {
             return static::badRequest();
@@ -43,5 +46,31 @@ class Tinebase_Webfinger
     protected static function badRequest(): \Laminas\Diactoros\Response
     {
         return new \Laminas\Diactoros\Response('php://memory', 400);
+    }
+
+    protected static function notFound(): \Laminas\Diactoros\Response
+    {
+        return new \Laminas\Diactoros\Response('php://memory', 404);
+    }
+
+    /*
+     * Some clients may have strange results if webfinger is present. 
+     */
+    protected static function unpleasantRequest(\Laminas\Diactoros\ServerRequest $request): bool
+    {
+        // OwnCloud client asks for SSO, Tine publishes webfinger regardless if SSO is enabled.
+        // Tested with Android App 4.3.0. 
+        //
+        // Better not ask for SSO > Tinebase_Application::getInstance()->getApplicationsByState(Tinebase_Application::ENABLED); <,
+        // even if there is no extra value if ownCloud instances are not listed; But there might be valid cases. 
+        $user_agent = $request->getHeader('User-Agent');
+        if(!empty($user_agent)) {
+            $ownCloud_agents = Tinebase_WebDav_Plugin_OwnCloud::USER_AGENTS;
+            if (preg_match('/('. implode('|', $ownCloud_agents) .')\/(\d+\.\d+\.\d+)/', $user_agent[0])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
I revised my PR from 3 month ago and aligned to today's app versions. Tested with **Android app release 4.3.0** and **iPhone app version 12.3.1**. While Android app is very robust/flexible in the iPhone app a lot of stuff is hardcoded (service discovery for SSO by webfinger, xml namespaces, http header for GET requests). 

Please merge before the yearly release - I need it ;-)