### PR TITLE
docker: nginx listen address/port

### DIFF
--- a/ci/dockerimage/gomplate/templates/nginx-vhost.conf.tmpl
+++ b/ci/dockerimage/gomplate/templates/nginx-vhost.conf.tmpl
@@ -1,0 +1,32 @@
+server {
+    include /etc/nginx/snippets/tine20-common.conf;
+
+    {{ if (ne (getenv "TINE20_ENTRYPOINT" "") "") }}
+    listen {{ getenv "TINE20_ENTRYPOINT" }};
+    {{ else }}
+    listen 80;
+    listen [::]:80;
+    {{ end }}
+
+    server_name {{ getenv "NGINXV_SERVER_NAME" "_"}};
+
+    root {{ getenv "TINE20ROOT" "/usr/share"}}/tine20;
+
+    error_log /dev/stderr;
+    access_log /dev/stdout {{getenv "NGINXV_LOG_FORMAT" "tine20"}};
+
+    set $PHP_ADMIN_VALUE "error_log = /var/log/nginx/php-error.log";
+    set $PHP_VALUE "include_path={{getenv "NGINXV_TINE20_CONFIG_DIR" "/etc/tine20"}}:/usr/share/tine20";
+
+
+    {{if not (eq (getenv "BROADCASTHUB_URL" "") "")}}
+    location /broadcasthub {
+        proxy_pass {{ getenv "BROADCASTHUB_URL" }};
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+    {{ end }}
+
+    include /etc/nginx/snippets/tine20-locations.conf;
+}


### PR DESCRIPTION
instead of at all (docker) interfaces on port 80. See issue https://github.com/tine-groupware/tine/issues/170

For unknown reason, this template does not exist yet. However, it is already referenced in ci/dockerimage/gomplate/config.yaml and will be written accordingly... (probably the file is injected only in release building)